### PR TITLE
Fix incorrect usage type

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ It is also possible to manually initialize the `Invoice`
 ```js
 const { Invoice } = require("alby-tools");
 
-const invoice = new Invoice({ paymentRequest: pr, preimage: preimage });
+const invoice = new Invoice({ pr: pr, preimage: preimage });
 await invoice.isPaid();
 ```
 


### PR DESCRIPTION
The example to create an invoice from a payment request and a preimage in README.md had an incorrect argument `paymentRequest` when the correct property is `pr`

In [`src/types.ts:53`](https://github.com/getAlby/js-lightning-tools/blob/master/src/types.ts#L53), the InvoiceArgs type takes `pr`, `verify`, and `preimage` with no reference to `paymentRequest`.

```ts
export type InvoiceArgs = {
  pr: string;
  verify?: string;
  preimage?: string;
};
```