### PR TITLE
fix: correct readme instructions on how to access fiat methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ await fetchWithL402(
 
 ```js
 import { l402 } from "@getalby/lightning-tools";
+import { fiat } from "@getalby/lightning-tools"
 
 // do not store the tokens
 await l402.fetchWithL402(
@@ -258,9 +259,9 @@ Like `getFiatValue` but returns a formatted string for a given locale using Java
 #### Examples
 
 ```js
-await getFiatValue(satoshi: 2100, currency: 'eur');
-await getSatoshiValue(amount: 100, currency: 'eur'); // for 1 EUR
-await getFormattedFiatValue(satoshi: 2100, currency: 'usd', locale: 'en')
+await fiat.getFiatValue({satoshi: 2100, currency: 'eur'});
+await fiat.getSatoshiValue({amount: 100, currency: 'eur'}); // for 1 EUR
+await fiat.getFormattedFiatValue({satoshi: 2100, currency: 'usd', locale: 'en'})
 ```
 
 ### 🤖 Lightning Address Proxy


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [ ]  ♻️ Refactor
- [ ]  ✨ New Feature
- [ ]  🐛 Bug Fix
- [x]  📝 Documentation Update
- [ ]  👷 Example Application
- [ ]  🧑‍💻 Code Snippet
- [ ]  🎨 Design
- [ ]  📖 Content
- [ ]  🧪 Tests
- [ ]  🔖 Release
- [ ]  🚩 Other


### Description
This PR implements corrections to the fiat examples in the README by ensuring that an object is being passed to the fiat methods. It also shows users the correct way of using the getFiatValue, getSatoshiValue and getFormattedFiatValue as they cannot be imported directly from the @getalby/lightning-tools without first importing { fiat }

### Related Tickets & Documents
Resolves https://github.com/getAlby/js-lightning-tools/issues/128
