### PR TITLE
chore: set prettier trailing comma to vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.trailingComma": "all"
 }


### PR DESCRIPTION
Finally found the reason why it keeps removing the comma on save and then the pre commit command adds it back, phew!